### PR TITLE
fix types on tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1401,9 +1401,9 @@
       }
     },
     "typescript": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz",
-      "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.1.tgz",
+      "integrity": "sha1-7znN6ierrAtQAkLWcmq5DgyEZjE=",
       "dev": true
     },
     "unique-string": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "@types/pify": "^3.0.0",
     "gts": "latest",
     "mocha": "^4.0.0",
-    "typescript": "^2.5.3"
+    "typescript": "~2.6.0"
   }
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -13,11 +13,13 @@ describe('GoogleP12Pem', () => {
   });
 
   it('should provide error on bad filename and callback', done => {
-    getPem('./badfilename.p12', (err: Error, pem: string) => {
+    getPem('./badfilename.p12', (err, pem) => {
       assert(err);
       assert.equal(pem, null);
-      assert.ok(err.message.startsWith('ENOENT'));
-      done();
+      if (err) {
+        assert.ok(err.message.startsWith('ENOENT'));
+        done();
+      }
     });
   });
 
@@ -43,16 +45,18 @@ describe('GoogleP12Pem', () => {
 
   it('should return error on bad .p12 in callback', done => {
     assert.doesNotThrow(() => {
-      getPem(BADP12FILE, (err: Error, pem: string) => {
-        assert.equal(null, null);
-        assert(err.message.indexOf('Too few bytes to read') > -1);
-        done();
+      getPem(BADP12FILE, (err, pem) => {
+        assert(err);
+        if (err) {
+          assert(err.message.indexOf('Too few bytes to read') > -1);
+          done();
+        }
       });
     });
   });
 
   it('should work async when provided a callback', done => {
-    getPem(GOODP12FILE, (err: Error, pem: string) => {
+    getPem(GOODP12FILE, (err, pem) => {
       assert.ifError(err);
       assert.equal(expectedPem, pem);
       done();


### PR DESCRIPTION
For some reason these tests passed on node 8, and were failing on 4 and 6:
https://travis-ci.org/google/google-p12-pem/jobs/295535590

Not sure why it wasn't picked up by the PR.  Do we need to re-setup travis on the repo?