### PR TITLE
chore(package): revert unnecessary version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-p12-pem",
-  "version": "1.0.0",
+  "version": "0.1.2",
   "description": "Convert Google .p12 keys to .pem keys",
   "main": "build/src/index.js",
   "types": "./build/src/index.d.ts",


### PR DESCRIPTION
The bump will happen at package publish time. Put it back to 0.1.2.