### PR TITLE
chore(build): run lint as a separate job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,16 +3,11 @@ release_tags: &release_tags
   tags:
     only: /^v\d+(\.\d+){2}(-.*)?$/
 
-# "Include" for unit tests definition.
 unit_tests: &unit_tests
   steps:
     - checkout
-    - run:
-        name: Install modules and dependencies.
-        command: npm install
-    - run:
-        name: Run unit tests.
-        command: npm test
+    - run: npm install
+    - run: npm run test-only
     - run:
         name: Submit coverage data to codecov.
         command: npm run codecov
@@ -33,13 +28,17 @@ workflows:
           filters: *release_tags
       - node10:
           filters: *release_tags
-      - publish_npm:
+      - lint:
           requires:
             - node4
             - node6
             - node8
             - node9
             - node10
+          filters: *release_tags
+      - publish_npm:
+          requires:
+            - lint
           filters:
             branches:
               ignore: /.*/
@@ -71,19 +70,20 @@ jobs:
       - image: node:10
         user: node
     <<: *unit_tests
-
-  publish_npm:
+  lint:
     docker:
-      - image: node10
+      - image: node:8
         user: node
     steps:
       - checkout
-      - run:
-          name: Set NPM authentication.
-          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-      - run:
-          name: Install modules and dependencies.
-          command: npm install
-      - run:
-          name: Publish the module to npm.
-          command: npm publish
+      - run: npm install
+      - run: npm run check
+  publish_npm:
+    docker:
+      - image: node8
+        user: node
+    steps:
+      - checkout
+      - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+      - run: npm install
+      - run: npm publish

--- a/package.json
+++ b/package.json
@@ -9,15 +9,16 @@
     "gp12-pem": "build/src/bin/gp12-pem.js"
   },
   "scripts": {
-    "test": "nyc mocha build/test",
-    "check": "gts check",
+    "test": "npm run test-only",
+    "test-only": "nyc mocha build/test",
+    "check": "gts check && npm run license-check",
     "clean": "gts clean",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json",
     "compile": "tsc -p .",
     "fix": "gts fix",
     "prepare": "npm run compile",
     "pretest": "npm run compile",
-    "posttest": "npm run check && npm run license-check",
+    "posttest": "npm run check",
     "license-check": "jsgl --local ."
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "compile": "tsc -p .",
     "fix": "gts fix",
     "prepare": "npm run compile",
-    "pretest": "npm run compile",
+    "pretest-only": "npm run compile",
     "posttest": "npm run check",
     "license-check": "jsgl --local ."
   },


### PR DESCRIPTION
This separates the lint step out from the other build steps.  There are a few reasons this is good:
- There's no need to run lint and license check for each version of nodejs we want to support
- We need nodejs 4 support for this library, and gts don't support it